### PR TITLE
HTTP proxyにリクエスト元プログラム制限機能を追加

### DIFF
--- a/ProxyHttpServer/LimitSrcProg.cs
+++ b/ProxyHttpServer/LimitSrcProg.cs
@@ -41,25 +41,27 @@ namespace ProxyHttpServer {
         }
 
         public bool IsAllow(SockObj sockObj, ref string error) {
-            if (!IsLocalIpAddress(sockObj.LocalAddress.Address)) {
+            string progname = "";
+            if (!IsLocalIpAddress(sockObj.RemoteAddress.Address)) {
                 //localhost上でない場合、アクセス元プログラム名取得は未対応
-                return true;
-            }
-            string progname = GetSrcProg(sockObj);
-            _logger.Set(LogKind.Debug, null, 999, string.Format("limitSrcProg:{0}", progname));
-            if (_allowList.Contains(progname)) {
-                //allowでヒットした場合は、常にALLOW
-                error = string.Format("AllowProg={0}", progname);
-                return true;
-            }
-            if (_denyList.Contains(progname)) {
-                //denyでヒットした場合は、常にDENY
-                error = string.Format("DenyProg={0}", progname);
-                return false;
+                progname = "SrcProg not supported for host other than localhost";
+            } else {
+                progname = GetSrcProg(sockObj);
+                _logger.Set(LogKind.Debug, null, 999, string.Format("limitSrcProg:{0}", progname));
+                if (_allowList.Contains(progname)) {
+                    //allowでヒットした場合は、常にALLOW
+                    error = string.Format("AllowProg={0}", progname);
+                    return true;
+                }
+                if (_denyList.Contains(progname)) {
+                    //denyでヒットした場合は、常にDENY
+                    error = string.Format("DenyProg={0}", progname);
+                    return false;
+                }
             }
             if (_denyList.Count == 0 && _allowList.Count > 0) {
                 //Allowだけ設定されている場合
-                error = string.Format("don't agree in an ALLOW Prog list {0}", progname);
+                error = string.Format("don't agree in an ALLOW Prog list. {0}", progname);
                 return false;//DENY
             }
             //Denyだけ設定されている場合

--- a/ProxyHttpServer/LimitSrcProg.cs
+++ b/ProxyHttpServer/LimitSrcProg.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text.RegularExpressions;
+using System.Runtime.InteropServices;
+using System.Net.Sockets;
+using System.Diagnostics;
+using Bjd.log;
+using Bjd.option;
+using Bjd.sock;
+
+namespace ProxyHttpServer {
+    //アクセス元プログラム制限
+    internal class LimitSrcProg {
+        //https://code.msdn.microsoft.com/windowsdesktop/C-Sample-to-list-all-the-4817b58f
+        private const int AF_INET = 2; //IPv4
+        private const int AF_INET6 = 23; //IPv6
+        [DllImport("iphlpapi.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        private static extern uint GetExtendedTcpTable(IntPtr pTcpTable, ref int pdwSize,
+            bool bOrder, int ulAf, TcpTableClass tableClass, uint reserved = 0);
+
+        readonly Logger _logger;
+        readonly List<string> _allowList = new List<string>();
+        readonly List<string> _denyList = new List<string>();
+
+        public LimitSrcProg(Logger logger, IEnumerable<OneDat> allow, IEnumerable<OneDat> deny) {
+            _logger = logger;
+            foreach (var o in allow) {
+                if (o.Enable) { //有効なデータだけを対象にする
+                    _allowList.Add(o.StrList[0]);
+                }
+            }
+            foreach (var o in deny) {
+                if (o.Enable) { //有効なデータだけを対象にする
+                    _denyList.Add(o.StrList[0]);
+                }
+            }
+        }
+
+        public bool IsAllow(SockObj sockObj, ref string error) {
+            string progname = GetSrcProg(sockObj);
+            _logger.Set(LogKind.Debug, null, 999, string.Format("progname={0}", progname));
+            if (_allowList.Contains(progname)) {
+                //allowでヒットした場合は、常にALLOW
+                error = string.Format("AllowProg={0}", progname);
+                return true;
+            }
+            if (_denyList.Contains(progname)) {
+                //denyでヒットした場合は、常にDENY
+                error = string.Format("DenyProg={0}", progname);
+                return false;
+            }
+            if (_denyList.Count == 0 && _allowList.Count > 0) {
+                //Allowだけ設定されている場合
+                error = string.Format("don't agree in an ALLOW Prog list {0}", progname);
+                return false;//DENY
+            }
+            //Denyだけ設定されている場合
+            //両方設定されている場合
+            return true;//ALLOW
+        }
+
+        // acquire progname from source port of sockObj
+        private string GetSrcProg(SockObj sockObj)
+        {
+            int port = sockObj.RemoteAddress.Port;
+            int af = AF_INET;
+            if (sockObj.LocalAddress.AddressFamily == AddressFamily.InterNetworkV6) {
+                af = AF_INET6;
+            }
+
+            int bufferSize = 0;
+            // Getting the size of TCP table, that is returned in 'bufferSize' variable.
+            uint result = GetExtendedTcpTable(IntPtr.Zero, ref bufferSize, false, af,
+                TcpTableClass.TCP_TABLE_OWNER_PID_CONNECTIONS);
+
+            // Allocating memory from the unmanaged memory of the process by using the
+            // specified number of bytes in 'bufferSize' variable.
+            IntPtr tcpTableRecordsPtr = Marshal.AllocHGlobal(bufferSize);
+
+            try
+            {
+                // The size of the table returned in 'bufferSize' variable in previous
+                // call must be used in this subsequent call to 'GetExtendedTcpTable'
+                // function in order to successfully retrieve the table.
+                result = GetExtendedTcpTable(tcpTableRecordsPtr, ref bufferSize, false,
+                    af, TcpTableClass.TCP_TABLE_OWNER_PID_CONNECTIONS);
+
+                // Non-zero value represent the function 'GetExtendedTcpTable' failed
+                if (result != 0)
+                    return "";
+
+                // Marshals data from an unmanaged block of memory to a newly allocated
+                // managed object 'tcpRecordsTable' of type 'MIB_TCPTABLE_OWNER_PID'
+                // to get number of entries of the specified TCP table structure.
+                if (af == AF_INET6) {
+                    MIB_TCP6TABLE_OWNER_PID tcpRecordsTable = (MIB_TCP6TABLE_OWNER_PID)
+                                            Marshal.PtrToStructure(tcpTableRecordsPtr,
+                                            typeof(MIB_TCP6TABLE_OWNER_PID));
+                    IntPtr tableRowPtr = (IntPtr)((long)tcpTableRecordsPtr +
+                                            Marshal.SizeOf(tcpRecordsTable.dwNumEntries));
+                    for (int row = 0; row < tcpRecordsTable.dwNumEntries; row++)
+                    {
+                        MIB_TCP6ROW_OWNER_PID tcpRow = (MIB_TCP6ROW_OWNER_PID)Marshal.
+                            PtrToStructure(tableRowPtr, typeof(MIB_TCP6ROW_OWNER_PID));
+                        ushort p = BitConverter.ToUInt16(new byte[2] {
+                                    tcpRow.localPort[1],
+                                    tcpRow.localPort[0] }, 0);
+                        if (p == port) {
+                            int pid = tcpRow.owningPid;
+                            Process proc = Process.GetProcessById(pid);
+                            return proc.ProcessName;
+                        }
+                        tableRowPtr = (IntPtr)((long)tableRowPtr + Marshal.SizeOf(tcpRow));
+                    }
+                } else {
+                    MIB_TCPTABLE_OWNER_PID tcpRecordsTable = (MIB_TCPTABLE_OWNER_PID)
+                                            Marshal.PtrToStructure(tcpTableRecordsPtr,
+                                            typeof(MIB_TCPTABLE_OWNER_PID));
+                    IntPtr tableRowPtr = (IntPtr)((long)tcpTableRecordsPtr +
+                                            Marshal.SizeOf(tcpRecordsTable.dwNumEntries));
+                    // Reading and parsing the TCP records one by one from the table and
+                    // storing them in a list of 'TcpProcessRecord' structure type objects.
+                    for (int row = 0; row < tcpRecordsTable.dwNumEntries; row++)
+                    {
+                        MIB_TCPROW_OWNER_PID tcpRow = (MIB_TCPROW_OWNER_PID)Marshal.
+                            PtrToStructure(tableRowPtr, typeof(MIB_TCPROW_OWNER_PID));
+                        ushort p = BitConverter.ToUInt16(new byte[2] {
+                                    // remotePort==portのエントリはBJD自身
+                                    tcpRow.localPort[1],
+                                    tcpRow.localPort[0] }, 0);
+                        if (p == port) {
+                            int pid = tcpRow.owningPid;
+                            Process proc = Process.GetProcessById(pid);
+                            // XXX: ProcessNameは実行ファイル名を変更すれば
+                            // 容易に変更可能なので、制限を簡単に抜けられる
+                            return proc.ProcessName;
+                            // MainModule参照は"アクセスが拒否されました"例外。
+                            // (netstat -b同様に、管理者権限が必要?)
+                            //return proc.MainModule.FileName;
+                            //return proc.MainModule.ModuleName;
+                        }
+                        tableRowPtr = (IntPtr)((long)tableRowPtr + Marshal.SizeOf(tcpRow));
+                    }
+                }
+            } catch (OutOfMemoryException outOfMemoryException) {
+                _logger.Set(LogKind.Error, null, 9000038, outOfMemoryException.Message);
+            } catch (Exception exception) {
+                _logger.Set(LogKind.Error, null, 9000038, exception.Message);
+            } finally {
+                Marshal.FreeHGlobal(tcpTableRecordsPtr);
+            }
+            return "";
+        }
+    }
+
+    // Enum to define the set of values used to indicate the type of table returned by
+    // calls made to the function 'GetExtendedTcpTable'.
+    public enum TcpTableClass
+    {
+        TCP_TABLE_BASIC_LISTENER,
+        TCP_TABLE_BASIC_CONNECTIONS,
+        TCP_TABLE_BASIC_ALL,
+        TCP_TABLE_OWNER_PID_LISTENER,
+        TCP_TABLE_OWNER_PID_CONNECTIONS,
+        TCP_TABLE_OWNER_PID_ALL,
+        TCP_TABLE_OWNER_MODULE_LISTENER,
+        TCP_TABLE_OWNER_MODULE_CONNECTIONS,
+        TCP_TABLE_OWNER_MODULE_ALL
+    }
+
+    /// <summary>
+    /// The structure contains information that describes an IPv4 TCP connection with
+    /// IPv4 addresses, ports used by the TCP connection, and the specific process ID
+    /// (PID) associated with connection.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MIB_TCPROW_OWNER_PID
+    {
+        public uint state;
+        public uint localAddr;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+        public byte[] localPort;
+        public uint remoteAddr;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+        public byte[] remotePort;
+        public int owningPid;
+    }
+
+    /// <summary>
+    /// The structure contains a table of process IDs (PIDs) and the IPv4 TCP links that
+    /// are context bound to these PIDs.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MIB_TCPTABLE_OWNER_PID
+    {
+        public uint dwNumEntries;
+        [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.Struct,
+            SizeConst = 1)]
+        public MIB_TCPROW_OWNER_PID[] table;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MIB_TCP6ROW_OWNER_PID
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public byte[] localAddr;
+        public uint localScopeId;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+        public byte[] localPort;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public byte[] remoteAddr;
+        public uint remoteScopeId;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 4)]
+        public byte[] remotePort;
+        public uint state;
+        public int owningPid;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct MIB_TCP6TABLE_OWNER_PID
+    {
+        public uint dwNumEntries;
+        [MarshalAs(UnmanagedType.ByValArray, ArraySubType = UnmanagedType.Struct,
+            SizeConst = 1)]
+        public MIB_TCP6ROW_OWNER_PID[] table;
+    }
+}

--- a/ProxyHttpServer/Option.cs
+++ b/ProxyHttpServer/Option.cs
@@ -29,6 +29,8 @@ namespace ProxyHttpServer {
             pageList.Add(Page5(key, Lang.Value(key), kernel));
             key = "LimitContents";
             pageList.Add(Page6(key, Lang.Value(key), kernel));
+            key = "LimitSrcProg";
+            pageList.Add(Page7(key, Lang.Value(key), kernel));
             pageList.Add(PageAcl());
             Add(new OneVal("tab", null, Crlf.Nextline, new CtrlTabPage("tabPage", pageList)));
 
@@ -154,6 +156,21 @@ namespace ProxyHttpServer {
             l.Add(new OneVal(key, "", Crlf.Nextline, new CtrlTextBox(Lang.Value(key), 50)));
             key = "limitString";
             onePage.Add(new OneVal(key, null, Crlf.Nextline, new CtrlDat(Lang.Value(key), l, 300, Lang.LangKind)));
+            return onePage;
+        }
+        private OnePage Page7(string name, string title, Kernel kernel){
+            var onePage = new OnePage(name, title);
+            var list1 = new ListVal();
+            var key = "allowProg";
+            list1.Add(new OneVal(key, "", Crlf.Nextline, new CtrlTextBox(Lang.Value(key), 50)));
+            key = "limitSrcProgAllow";
+            onePage.Add(new OneVal(key, null, Crlf.Nextline, new CtrlDat(Lang.Value(key), list1, 185, Lang.LangKind)));
+            var list2 = new ListVal();
+            key = "denyProg";
+            list2.Add(new OneVal(key, "", Crlf.Nextline, new CtrlTextBox(Lang.Value(key), 50)));
+            key = "limitSrcProgDeny";
+            onePage.Add(new OneVal(key, null, Crlf.Nextline, new CtrlDat(Lang.Value(key), list2, 185, Lang.LangKind)));
+
             return onePage;
         }
 

--- a/ProxyHttpServer/ProxyHttpServer.csproj
+++ b/ProxyHttpServer/ProxyHttpServer.csproj
@@ -54,7 +54,6 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/ProxyHttpServer/ProxyHttpServer.csproj
+++ b/ProxyHttpServer/ProxyHttpServer.csproj
@@ -70,6 +70,7 @@
     </Compile>
     <Compile Include="HttpMethod.cs" />
     <Compile Include="HttpSideState.cs" />
+    <Compile Include="LimitSrcProg.cs" />
     <Compile Include="LimitString.cs" />
     <Compile Include="LimitUrl.cs" />
     <Compile Include="Log.cs" />

--- a/ProxyHttpServer/ProxyHttpServer.csproj
+++ b/ProxyHttpServer/ProxyHttpServer.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,74 @@
 BlackJumboDog
 =============
+fork from https://github.com/furuya02/bjd5
 
+## 追加機能
+HTTP proxyにリクエスト元プログラム制限機能を追加します。
+
+### 概要
+HTTP proxyリクエストの送信元プログラム名をチェックして、
+ホワイトリストにあるプログラムからのリクエストのみを中継する機能を、
+BlackJumboDogのHTTP proxyに追加したものです。
+
+socket接続元ポート番号から、該当するプロセスIDを取得して、
+プロセスIDからプログラム名(フルパス)を取得します。
+localhostで動かす想定です。
+
+### 背景
+会社内ネットワークからのインターネットアクセスは認証proxy経由。
+マルウェア対策としてproxy認証が必須になっているのですが、
+proxy認証用ユーザIDとパスワードを、
+ユーザまたは機器ごと、各ツール/プログラムごとに設定する必要があって、
+開発環境構築時など、生産性が数%は落ちている気がします。
+
+なので、たいていは、上位proxyとして認証proxyを設定した、
+認証無しproxy(polipo等)を各PCで動かして使いたくなるのですが、
+そうするとマルウェア対策を弱めている形になるのであまり良くない気もします。
+(システムのproxy設定を参照するマルウェアがインターネットアクセス可能になるので)
+
+そこで、マルウェア対策を弱めずに、
+認証用のID/パスワードを各ツール/プログラムごとに設定する繁雑さを減らす目的で
+試作しました。
+(ただし、各ツール/プログラムに(認証無し)proxy設定(localhost:8080等)をする必要はあり。)
+
+### セットアップ
+* [BlackJumboDog v6.2.0](https://forest.watch.impress.co.jp/library/software/blackjmbdog/)をインストール。
+* BlackJumboDogのインストールディレクトリにある、
+  ProxyHttpServer.dllとBJD.Lang.txtファイルを、
+  アクセス元プログラム制限機能追加版で上書き。
+  * [ProxyHttpServer.dll](https://github.com/deton/bjd5/releases)
+  * [BJD.Lang.txt](https://github.com/deton/bjd5/blob/master/SetupFiles/BJD.Lang.txt)
+
+### 使い方
+BJD.exe起動後、「オプション」→「プロキシサーバ」→「ブラウザ」ダイアログで、
+「プロキシサーバ[Browser]を使用する」。
+「ACL」タブで127.0.0.1を許可。
+「アクセス元プログラム制限」タブで、許可するプログラムのフルパスを追加。
+
+プログラムのフルパスは、アクセス元プログラムでBJDをproxyサーバに指定して
+リクエストを発行した際の、BJD側ログからコピーするのが早いかも。
+
+例: Git Bashのcurlの場合、
+`curl -x localhost:8080 http://www.google.co.jp`
+を実行。フルパスは、
+`C:\Program Files\Git\mingw64\bin\curl.exe`
+
+### 参考: BlackJumboDog変更以外の実現方法案
+* [.NET Core CLR版BlackJumboDog](https://github.com/darkcrash/bjd5)
+* [Windows用Squid](http://squid.diladele.com/)
+  でurl_rewrite_programとして作成しようとしてみたが、
+  stdinから何も読めないので断念
+* Windows版[polipo](https://github.com/jech/polipo)はredirector未対応。
+  polipoに対するredirector対応と接続元ポート番号を渡す変更が必要になるので見送り。
+* [goproxy](https://github.com/elazarl/goproxy)ライブラリを使ってproxyサーバ自作する方法は、proxyサーバ本体機能をいろいろ作る必要がありそうだったので見送り。
+* [3proxy](http://3proxy.ru)のプラグインDLLとして作成する方法は、
+  C/C++で書くのが少しおっくうだったのと、3proxy自体の設定ファイルがわかりにくい気がしたので見送り。
+* [Delegatedのドキュメント](https://i-red.info/docs/Manual.htm?AUTHORIZER)を見たが、
+  外部コマンドに接続元ポート番号を渡す方法を見つけられなかったので見送り。
+
+## 参考
+* Windows用ローカルプロキシ: [認証プロキシ爆発しろ！](http://ipponshimeji.cocolog-nifty.com/blog/2017/01/post-0ce6.html)
+* [LuLu - 外向きのネットワークトラフィックを監視するファイアウォール](https://www.moongift.jp/2018/02/lulu-%e5%a4%96%e5%90%91%e3%81%8d%e3%81%ae%e3%83%8d%e3%83%83%e3%83%88%e3%83%af%e3%83%bc%e3%82%af%e3%83%88%e3%83%a9%e3%83%95%e3%82%a3%e3%83%83%e3%82%af%e3%82%92%e7%9b%a3%e8%a6%96%e3%81%99%e3%82%8b/)
+
+## License
 [Apache License Version 2.0](LICENSE)

--- a/SetupFiles/BJD.Lang.txt
+++ b/SetupFiles/BJD.Lang.txt
@@ -293,6 +293,7 @@ OptionProxyHttp_Cache1	キャッシュ(1)	Cache(1)
 OptionProxyHttp_Cache2	キャッシュ(2)	Cache(2)
 OptionProxyHttp_LimitUrl	ＵＲＬ制限	URL Restriction
 OptionProxyHttp_LimitContents	コンテンツ制限	Contents restriction
+OptionProxyHttp_LimitSrcProg	アクセス元プログラム制限	Source program restriction
 
 # Page1(基本設定)
 
@@ -361,6 +362,14 @@ OptionProxyHttp_limitUrlDeny	制限するURL	Deny these URL
 
 OptionProxyHttp_string	文字列	String
 OptionProxyHttp_limitString	次の文字列を含むアクセスを制限する	Deny access if the content contains these strings
+
+# Page7(アクセス元プログラム制限)
+
+OptionProxyHttp_allowProg	プログラム名	Program name
+OptionProxyHttp_limitSrcProgAllow	許可するプログラム	Allow these programs
+
+OptionProxyHttp_denyProg	プログラム名	Program name
+OptionProxyHttp_limitSrcProgDeny	制限するプログラム	Deny these programs
 
 #Message
 


### PR DESCRIPTION
### 概要
HTTP proxyリクエストの送信元プログラム名をチェックして、
ホワイトリストにあるプログラムからのリクエストのみを中継する機能を、
BlackJumboDogのHTTP proxyに追加したものです。

socket接続元ポート番号から、該当するプロセスIDを取得して、
プロセスIDからプログラム名(フルパス)を取得します。
localhostで動かす想定です。

### 背景
会社内ネットワークからのインターネットアクセスは認証proxy経由。
マルウェア対策としてproxy認証が必須になっているのですが、
proxy認証用ユーザIDとパスワードを、
ユーザまたは機器ごと、各ツール/プログラムごとに設定する必要があって、
開発環境構築時など、生産性が数%は落ちている気がします。

なので、たいていは、上位proxyとして認証proxyを設定した、
認証無しproxy(polipo等)を各PCで動かして使いたくなるのですが、
そうするとマルウェア対策を弱めている形になるのであまり良くない気もします。
(システムのproxy設定を参照するマルウェアがインターネットアクセス可能になるので)

そこで、マルウェア対策を弱めずに、
認証用のID/パスワードを各ツール/プログラムごとに設定する繁雑さを減らす目的で
試作しました。
(ただし、各ツール/プログラムに(認証無し)proxy設定(localhost:8080等)をする必要はあり。)
